### PR TITLE
Add LagomKafkaComponents

### DIFF
--- a/helloworld-producer-impl/src/main/scala/sample/helloworld/impl/HelloLoader.scala
+++ b/helloworld-producer-impl/src/main/scala/sample/helloworld/impl/HelloLoader.scala
@@ -5,6 +5,7 @@ package sample.helloworld.impl
   */
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.broker.kafka.LagomKafkaComponents
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraPersistenceComponents
 import com.lightbend.lagom.scaladsl.server._
@@ -26,6 +27,7 @@ class HelloLoader extends LagomApplicationLoader {
 abstract class HelloApplication(context: LagomApplicationContext)
   extends LagomApplication(context)
     with CassandraPersistenceComponents
+    with LagomKafkaComponents
     with AhcWSComponents {
 
   // Bind the services that this server provides

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 logLevel := Level.Debug
 
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.0-RC1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.0-RC2")


### PR DESCRIPTION
Also updates Lagom to 1.3.0-RC2, which includes a warning when
LagomKafkaComponents are not included in a service that declares topics.